### PR TITLE
relax Faraday version requirement

### DIFF
--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
-  spec.add_dependency 'faraday', '~> 2'
+  spec.add_dependency 'faraday'
   spec.add_dependency 'faraday-multipart', '~> 1'
-  spec.add_dependency 'faraday-retry', '~> 2'
+  spec.add_dependency 'faraday-retry'
   spec.add_dependency 'zeitwerk', '~> 2'
 end


### PR DESCRIPTION
The core functions of this gem work fine with the older version of `faraday` that our app is currently pinned to.  Relaxing this requirement allows us to add it to the app's bundle.